### PR TITLE
Fix Gmail Filters

### DIFF
--- a/src/yumyum.js
+++ b/src/yumyum.js
@@ -13,7 +13,7 @@ const fetchLatestMenuEmail = () => {
     config.features.dateFilter ? `after:${today}` : ""
   ];
 
-  return findEmail(filters.join(""));
+  return findEmail(filters.join(" "));
 };
 
 const extractMenuImageUrl = html => {


### PR DESCRIPTION
Currently, Gmail filters are being joined by `""` instead of `" "`